### PR TITLE
ensure survey id, published, unpublished and versionId are reset before saving new survey version

### DIFF
--- a/actions/study/surveys.ts
+++ b/actions/study/surveys.ts
@@ -14,6 +14,10 @@ export const createNewSurvey = async (studyKey: string, survey: Survey) => {
 
     let url = `/v1/studies/${studyKey}/surveys`;
 
+    survey.id = undefined;
+    survey.published = undefined;
+    survey.unpublished = undefined;
+    survey.versionId = ''
     const resp = await fetchCASEManagementAPI(url,
         session.CASEaccessToken,
         {
@@ -35,6 +39,10 @@ export const uploadSurvey = async (studyKey: string, surveyKey: string, survey: 
     }
 
     let url = `/v1/studies/${studyKey}/surveys/${surveyKey}`;
+    survey.id = undefined;
+    survey.unpublished = undefined;
+    survey.published = undefined;
+    survey.versionId = ''
 
     const resp = await fetchCASEManagementAPI(url,
         session.CASEaccessToken,

--- a/app/(default)/tools/study-configurator/[studyKey]/surveys/[surveyKey]/_components/UploadSurveyDialog.tsx
+++ b/app/(default)/tools/study-configurator/[studyKey]/surveys/[surveyKey]/_components/UploadSurveyDialog.tsx
@@ -108,6 +108,11 @@ const UploadSurveyDialog: React.FC<UploadSurveyDialogProps> = ({
                                             setErrorMsg('Survey key in the uploaded file does not match the current survey key. Should be "' + surveyKey + '".');
                                             return;
                                         }
+                                        const newSurvey = data as Survey;
+                                        newSurvey.id = undefined;
+                                        newSurvey.published = undefined;
+                                        newSurvey.unpublished = undefined;
+                                        newSurvey.versionId = ''
                                         setNewSurvey(data as Survey);
                                     } else {
                                         setNewSurvey(undefined);


### PR DESCRIPTION
This pull request includes changes to ensure that certain fields in the survey object are reset to their initial states when creating or uploading a survey. This helps maintain consistency and prevents unintended data from being carried over.

