### PR TITLE
add editor for mapToKey

### DIFF
--- a/components/survey-editor/components/ItemEditor/editor/components/advanced-configs/advanced-configs.tsx
+++ b/components/survey-editor/components/ItemEditor/editor/components/advanced-configs/advanced-configs.tsx
@@ -1,3 +1,4 @@
+import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
@@ -18,6 +19,7 @@ const AdvancedConfigs: React.FC<AdvancedConfigsProps> = (props) => {
     const onToggleConfidentialMode = (checked: boolean) => {
         if (!checked) {
             currentItem.confidentialMode = undefined;
+            currentItem.mapToKey = undefined;
         } else {
             currentItem.confidentialMode = 'replace';
         }
@@ -44,26 +46,52 @@ const AdvancedConfigs: React.FC<AdvancedConfigsProps> = (props) => {
             </div>
 
             {confidentialModeOn && (
-                <fieldset className='space-y-2 flex'>
-                    <legend className='font-semibold text-sm'>Confidential mode</legend>
-                    <div>
-                        <Select value={currentItem.confidentialMode || ''}
-                            onValueChange={(value) => {
-                                currentItem.confidentialMode = value as 'replace' | 'add';
+                <>
+
+                    <fieldset className='space-y-2 flex'>
+                        <legend className='font-semibold text-sm'>Confidential mode</legend>
+                        <div>
+                            <Select value={currentItem.confidentialMode || ''}
+                                onValueChange={(value) => {
+                                    currentItem.confidentialMode = value as 'replace' | 'add';
+                                    props.onUpdateSurveyItem(currentItem);
+                                }}
+                            >
+
+                                <SelectTrigger className='w-64'>
+                                    <SelectValue placeholder="Select a confidential mode..." />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value='replace'>Replace</SelectItem>
+                                    <SelectItem value='add'>Add</SelectItem>
+                                </SelectContent>
+                            </Select>
+                        </div>
+                    </fieldset>
+                    <div className='space-y-1.5'>
+                        <Label
+                            htmlFor="mapToKey"
+                            className='text-sm font-semibold'
+                        >
+                            Map to key (optional)
+                        </Label>
+                        <Input
+                            id="mapToKey"
+                            type="text"
+                            value={currentItem.mapToKey || ''}
+                            onChange={(e) => {
+                                const value = e.target.value;
+
+                                currentItem.mapToKey = value === '' ? undefined : value;
                                 props.onUpdateSurveyItem(currentItem);
                             }}
-                        >
-
-                            <SelectTrigger className='w-64'>
-                                <SelectValue placeholder="Select a confidential mode..." />
-                            </SelectTrigger>
-                            <SelectContent>
-                                <SelectItem value='replace'>Replace</SelectItem>
-                                <SelectItem value='add'>Add</SelectItem>
-                            </SelectContent>
-                        </Select>
+                            placeholder='Enter a key...'
+                        />
+                        <p className='text-xs text-muted-foreground'>
+                            The response for this item will be saved in the confidential data store with the key provided here.
+                        </p>
                     </div>
-                </fieldset>
+                </>
             )}
         </div>
     );

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
 		"react-spinners": "^0.13.8",
 		"rehype-raw": "^7.0.0",
 		"sonner": "^1.5.0",
-		"survey-engine": "^1.3.0",
+		"survey-engine": "^1.3.1",
 		"swr": "^2.2.4",
 		"tailwind-merge": "^2.5.2",
 		"tailwindcss-animate": "^1.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5633,10 +5633,10 @@ survey-engine@^1.2.0:
   dependencies:
     date-fns "^2.29.3"
 
-survey-engine@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/survey-engine/-/survey-engine-1.3.0.tgz#d992a9f0205efc110f1be7d1cc7649c12324d6ad"
-  integrity sha512-81ThTUZPDA51Ssn+UW6awKAaSlAFrmX5RBd0mtP4tJez6AMKh8uyKSu3I0U+Z3o812nvLXPVazM9P201zxmH3w==
+survey-engine@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/survey-engine/-/survey-engine-1.3.1.tgz#2c5a8e0b4f60c100f6aac2e3a050b6f70a188755"
+  integrity sha512-q7i3xsAXSOT7ksqC4SooPnT586EhdrGqTcDJ+XNyZt9Zej6VtAPyiBJSpZdE85kJEQuvPW+0S0Y/mxjk1svdqA==
   dependencies:
     date-fns "^2.29.3"
 


### PR DESCRIPTION
This pull request includes several changes to the `AdvancedConfigs` component in the survey editor and an update to the `survey-engine` dependency in `package.json`. The most important changes include adding a new input field for mapping keys in confidential mode, updating the dependency version, and minor code adjustments.

### Enhancements to `AdvancedConfigs` Component:

* Added an `Input` component import to `advanced-configs.tsx`. 
* Introduced a new input field for `mapToKey` when confidential mode is enabled. This allows users to map responses to a specific key in the confidential data store. 
* Updated the `onToggleConfidentialMode` function to reset `mapToKey` when confidential mode is turned off. 

### Dependency Update:

* Updated the `survey-engine` dependency version from `^1.3.0` to `^1.3.1` in `package.json`.