### PR TITLE
table and download flow for daily response data files

### DIFF
--- a/app/(default)/tools/participants/[studyKey]/responses/exporter/_components/ExporterTabs.tsx
+++ b/app/(default)/tools/participants/[studyKey]/responses/exporter/_components/ExporterTabs.tsx
@@ -1,11 +1,10 @@
-'use client';
-
-import React from 'react';
+import React, { Suspense } from 'react';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import SurveyInfoDownloader from './SurveyInfoDownloader';
 import ResponseDownloader from './ResponseDownloader';
 import ConfidentialResponseDownloader from './ConfidentialResponseDownloader';
+import DailyExportsLoader, { DailyExportsLoaderSkeleton } from './daily-exports-loader';
 
 interface ExporterTabsProps {
     studyKey: string;
@@ -28,7 +27,7 @@ const ExporterTabs: React.FC<ExporterTabsProps> = (props) => {
                 </CardHeader>
                 <CardContent>
                     <p className='font-bold'>What do you want to export:</p>
-                    <Tabs defaultValue="responses" className="w-auto mt-2">
+                    <Tabs defaultValue="dailyResponses">
                         <TabsList>
                             <TabsTrigger value="responses">Responses</TabsTrigger>
                             <TabsTrigger value="surveyInfo">
@@ -36,6 +35,9 @@ const ExporterTabs: React.FC<ExporterTabsProps> = (props) => {
                             </TabsTrigger>
                             <TabsTrigger value="confidentialResponses">
                                 Confidential Responses
+                            </TabsTrigger>
+                            <TabsTrigger value="dailyResponses">
+                                Daily Response Exports
                             </TabsTrigger>
                         </TabsList>
                         <TabsContent value="responses">
@@ -54,6 +56,13 @@ const ExporterTabs: React.FC<ExporterTabsProps> = (props) => {
                             <ConfidentialResponseDownloader
                                 studyKey={props.studyKey}
                             />
+                        </TabsContent>
+                        <TabsContent value="dailyResponses">
+                            <Suspense fallback={<DailyExportsLoaderSkeleton />}>
+                                <DailyExportsLoader
+                                    studyKey={props.studyKey}
+                                />
+                            </Suspense>
                         </TabsContent>
                     </Tabs>
                 </CardContent>

--- a/app/(default)/tools/participants/[studyKey]/responses/exporter/_components/dail-exports-client.tsx
+++ b/app/(default)/tools/participants/[studyKey]/responses/exporter/_components/dail-exports-client.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import LoadingButton from '@/components/LoadingButton';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import React, { useState } from 'react';
+import { toast } from 'sonner';
+
+export interface DailyExport {
+    id: number;
+    filename: string;
+    surveyKey: string;
+    date: string;
+}
+
+interface DailExportsClientProps {
+    studyKey: string;
+    dailyExports: Array<DailyExport>;
+}
+
+const DailExportsClient: React.FC<DailExportsClientProps> = (props) => {
+    const [selectedFiles, setSelectedFiles] = useState<number[]>([])
+    const [isPending, startTransition] = React.useTransition();
+
+    const handleSelectFile = (id: number) => {
+        setSelectedFiles(prev =>
+            prev.includes(id) ? prev.filter(fileId => fileId !== id) : [...prev, id]
+        )
+    }
+    const handleSelectAll = () => {
+        setSelectedFiles(
+            selectedFiles.length === props.dailyExports.length
+                ? []
+                : props.dailyExports.map(file => file.id)
+        )
+    }
+
+    const handleDownload = () => {
+        startTransition(async () => {
+            for (const file of selectedFiles) {
+                const filename = props.dailyExports.find(e => e.id === file)?.filename;
+                if (!filename) {
+                    toast.error('Failed to download file');
+                    return;
+                }
+                const encodedFilename = btoa(filename);
+                try {
+                    const resp = await fetch(`/api/case-management-api/v1/studies/${props.studyKey}/data-exporter/responses/daily-exports/${encodedFilename}`, {
+                        method: 'GET',
+                        headers: {
+                            'Content-Type': 'application/json',
+                        },
+                    });
+                    if (resp.status !== 200) {
+                        toast.error('Failed to download file', {
+                            description: resp.statusText
+                        });
+                        return;
+                    }
+                    const blob = await resp.blob();
+                    const url = window.URL.createObjectURL(blob);
+                    const a = document.createElement('a');
+                    a.href = url;
+                    const downloadFilename = resp.headers.get('Content-Disposition')?.split('filename=')[1] || filename;
+                    a.download = downloadFilename;
+                    document.body.appendChild(a);
+                    a.click();
+                    a.remove();
+                    toast.success(downloadFilename + ' downloaded');
+                } catch (e) {
+                    console.error(e);
+                    toast.error('Failed to download file');
+                }
+            }
+        });
+    }
+
+    let content = null;
+    if (props.dailyExports.length === 0) {
+        content = <div>
+            <p className=''>No daily exports available</p>
+            <p className='text-xs text-muted-foreground'>
+                Either the study has no daily exports configured or there is no data for the configured survey within the retention period.
+            </p>
+        </div>;
+    } else {
+        content = (
+            <div>
+                <div className="mb-4">
+                    <LoadingButton
+                        onClick={handleDownload}
+                        disabled={selectedFiles.length === 0}
+                        isLoading={isPending}
+                    >
+                        Download Selected ({selectedFiles.length})
+                    </LoadingButton>
+                </div>
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead className="w-[50px]">
+                                <Checkbox
+                                    checked={selectedFiles.length === props.dailyExports.length}
+                                    onCheckedChange={handleSelectAll}
+                                    aria-label="Select all files"
+                                />
+                            </TableHead>
+                            <TableHead>Date</TableHead>
+                            <TableHead>Survey Key</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {props.dailyExports.map((file) => (
+                            <TableRow key={file.id}
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    handleSelectFile(file.id)
+                                }}
+                                className='cursor-pointer h-6'
+                            >
+                                <TableCell className='flex items-center'>
+                                    <Checkbox
+                                        checked={selectedFiles.includes(file.id)}
+                                        onCheckedChange={() => handleSelectFile(file.id)}
+                                        aria-label={`Select file ${file.surveyKey}`}
+                                    />
+                                </TableCell>
+                                <TableCell>{file.date}</TableCell>
+                                <TableCell>{file.surveyKey}</TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            </div>
+        );
+    }
+    return (
+        <Card className='p-4'>
+            {content}
+        </Card>
+    );
+};
+
+export default DailExportsClient;

--- a/app/(default)/tools/participants/[studyKey]/responses/exporter/_components/daily-exports-loader.tsx
+++ b/app/(default)/tools/participants/[studyKey]/responses/exporter/_components/daily-exports-loader.tsx
@@ -1,0 +1,66 @@
+import ErrorAlert from '@/components/ErrorAlert';
+import { Card } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { getDailyResponseExports } from '@/lib/data/responses';
+import React from 'react';
+import DailExportsClient, { DailyExport } from './dail-exports-client';
+
+interface DailyExportsLoaderProps {
+    studyKey: string;
+}
+
+const DailyExportsLoader: React.FC<DailyExportsLoaderProps> = async (props) => {
+    const dailyExports = await getDailyResponseExports(props.studyKey);
+
+    if (dailyExports.error) {
+        return (<ErrorAlert
+            title='Error loading daily exports'
+            error={dailyExports.error}
+        />
+        )
+    }
+
+
+    const availableDailyExports: Array<DailyExport> = [];
+    if (dailyExports.dailyExports) {
+        for (let i = 0; i < dailyExports.dailyExports.length; i++) {
+            const dailyExport = dailyExports.dailyExports[i];
+            const parts = dailyExport.split('##');
+
+            if (parts.length < 3) {
+                continue;
+            }
+
+            availableDailyExports.push({
+                id: i,
+                filename: dailyExport,
+                surveyKey: parts[2],
+                date: parts[0],
+            })
+        }
+    }
+
+    availableDailyExports.sort((a, b) => {
+        return b.date.localeCompare(a.date);
+    });
+
+
+    return (
+        <DailExportsClient
+            studyKey={props.studyKey}
+            dailyExports={availableDailyExports}
+        />
+    );
+};
+
+export default DailyExportsLoader;
+
+export const DailyExportsLoaderSkeleton = () => {
+    return <Card className='p-4 space-y-1'>
+        <Skeleton className='h-8 w-full' />
+        <Skeleton className='h-6 w-full' />
+        <Skeleton className='h-6 w-full' />
+        <Skeleton className='h-6 w-full' />
+        <Skeleton className='h-6 w-full' />
+    </Card>
+}

--- a/lib/data/responses.ts
+++ b/lib/data/responses.ts
@@ -106,3 +106,31 @@ export const startResponseExport = async (
     }
     return resp.body;
 }
+
+export const getDailyResponseExports = async (
+    studyKey: string
+): Promise<{
+    error?: string,
+    dailyExports?: string[]
+}> => {
+    const session = await auth();
+    if (!session || !session.CASEaccessToken) {
+        return { error: 'Unauthorized' };
+    }
+
+    const queryParams = new URLSearchParams();
+    const queryString = queryParams.toString();
+    const url = `/v1/studies/${studyKey}/data-exporter/responses/daily-exports?${queryString}`;
+
+    const resp = await fetchCASEManagementAPI(
+        url,
+        session.CASEaccessToken,
+        {
+            revalidate: 0,
+        }
+    );
+    if (resp.status !== 200) {
+        return { error: `Failed to fetch daily response exports: ${resp.status} - ${resp.body.error}` };
+    }
+    return resp.body;
+}


### PR DESCRIPTION
This pull request introduces a new feature for exporting daily responses in the `ExporterTabs` component. The changes include adding a new tab for daily response exports, creating components to handle the loading and display of these exports, and implementing the necessary backend logic to fetch the data.

### New Feature: Daily Response Exports

* `app/(default)/tools/participants/[studyKey]/responses/exporter/_components/ExporterTabs.tsx`: Added a new "Daily Response Exports" tab and integrated the `DailyExportsLoader` component to handle the loading of daily exports. ([app/(default)/tools/participants/[studyKey]/responses/exporter/_components/ExporterTabs.tsxL1-R7](diffhunk://#diff-76f5cc1e11fdaa4a7922fcbf6a9052d1a9cd0ff076c5d18762cd3e87eb086892L1-R7), [app/(default)/tools/participants/[studyKey]/responses/exporter/_components/ExporterTabs.tsxL31-R30](diffhunk://#diff-76f5cc1e11fdaa4a7922fcbf6a9052d1a9cd0ff076c5d18762cd3e87eb086892L31-R30), [app/(default)/tools/participants/[studyKey]/responses/exporter/_components/ExporterTabs.tsxR39-R41](diffhunk://#diff-76f5cc1e11fdaa4a7922fcbf6a9052d1a9cd0ff076c5d18762cd3e87eb086892R39-R41), [app/(default)/tools/participants/[studyKey]/responses/exporter/_components/ExporterTabs.tsxR60-R66](diffhunk://#diff-76f5cc1e11fdaa4a7922fcbf6a9052d1a9cd0ff076c5d18762cd3e87eb086892R60-R66))

### New Components

* `app/(default)/tools/participants/[studyKey]/responses/exporter/_components/dail-exports-client.tsx`: Created `DailExportsClient` component to manage the display and download of daily exports. ([app/(default)/tools/participants/[studyKey]/responses/exporter/_components/dail-exports-client.tsxR1-R146](diffhunk://#diff-935f395fbbe520a673bca69f4e7aa0bc4355487a12c8fe488ec5765f2c4a384fR1-R146))
* `app/(default)/tools/participants/[studyKey]/responses/exporter/_components/daily-exports-loader.tsx`: Created `DailyExportsLoader` component to fetch and process daily response exports data, and `DailyExportsLoaderSkeleton` for loading state. ([app/(default)/tools/participants/[studyKey]/responses/exporter/_components/daily-exports-loader.tsxR1-R66](diffhunk://#diff-b6308e1dc67a799c4f317edd5cfacacfe4b881e6009655cb1ea2c5f0e3272977R1-R66))

### Backend Integration

* [`lib/data/responses.ts`](diffhunk://#diff-415a392b5700dc3b3ae095e860b8800c175ca9c83bc740072ed97b8deb5b7731R109-R136): Added `getDailyResponseExports` function to fetch daily response exports from the backend.