### PR TITLE
filter empty lines when parsing CSV

### DIFF
--- a/app/(default)/tools/participants/[studyKey]/actions/schedule-message/_components/participant-info-uploader.tsx
+++ b/app/(default)/tools/participants/[studyKey]/actions/schedule-message/_components/participant-info-uploader.tsx
@@ -47,15 +47,18 @@ const ParticipantInfoUploader: React.FC<ParticipantInfoUploaderProps> = (props) 
                             }
                             const delimiter = detectDelimiter(text);
                             const keys = lines[0].split(delimiter);
-                            const data = lines.slice(1).map(line => {
+                            const data = lines.filter(l => l.length > 0).slice(1).map(line => {
                                 const values = line.split(delimiter);
+                                if (values.length !== keys.length) {
+                                    return null;
+                                }
                                 const obj: Record<string, string> = {};
                                 for (let i = 0; i < keys.length; i++) {
                                     obj[keys[i]] = values[i];
                                 }
                                 return obj;
                             });
-                            props.onChange(data);
+                            props.onChange(data.filter(d => d !== null) as Record<string, string>[]);
                         } else {
                             props.onChange([]);
                         }


### PR DESCRIPTION
The change improves the handling of CSV data by ensuring that empty lines are ignored and that rows with mismatched column counts are filtered out before passing the data to the `onChange` handler.

Improvements to CSV data handling:

* `app/(default)/tools/participants/[studyKey]/actions/schedule-message/_components/participant-info-uploader.tsx`: Modified the `data` processing to filter out empty lines and rows with mismatched column counts before invoking the `onChange` handler. ([app/(default)/tools/participants/[studyKey]/actions/schedule-message/_components/participant-info-uploader.tsxL50-R61](diffhunk://#diff-b81a03eca5d81281fa0b9786bc2523b78c25048d5d8d816697baa382e9fc8d8aL50-R61))