### PR TITLE
remove redundant onCheckedChange handler from file selection checkbox

### DIFF
--- a/app/(default)/tools/participants/[studyKey]/responses/exporter/_components/dail-exports-client.tsx
+++ b/app/(default)/tools/participants/[studyKey]/responses/exporter/_components/dail-exports-client.tsx
@@ -122,7 +122,6 @@ const DailExportsClient: React.FC<DailExportsClientProps> = (props) => {
                                 <TableCell className='flex items-center'>
                                     <Checkbox
                                         checked={selectedFiles.includes(file.id)}
-                                        onCheckedChange={() => handleSelectFile(file.id)}
                                         aria-label={`Select file ${file.surveyKey}`}
                                     />
                                 </TableCell>


### PR DESCRIPTION
This pull request includes a small change to the `app/(default)/tools/participants/[studyKey]/responses/exporter/_components/dail-exports-client.tsx` file. The change modifies the `Checkbox` component to remove the `onCheckedChange` prop, which previously called the `handleSelectFile` function with the file's ID. Previously this blocked toggling selection when clicking on the checkbox compared to when clicking anywhere else on the row.

* `app/(default)/tools/participants/[studyKey]/responses/exporter/_components/dail-exports-client.tsx`: Removed the `onCheckedChange` prop from the `Checkbox` component. ([app/(default)/tools/participants/[studyKey]/responses/exporter/_components/dail-exports-client.tsxL125](diffhunk://#diff-935f395fbbe520a673bca69f4e7aa0bc4355487a12c8fe488ec5765f2c4a384fL125))