### PR TITLE
Textarea field sizing content

### DIFF
--- a/components/survey-editor/components/ItemEditor/editor/components/content-editor/response-editors/text-input-content-config.tsx
+++ b/components/survey-editor/components/ItemEditor/editor/components/content-editor/response-editors/text-input-content-config.tsx
@@ -22,8 +22,7 @@ const TextInputContentConfig: React.FC<TextInputContentConfigProps> = (props) =>
     const currentPlaceholder = localisedObjectToMap(props.component.description).get(selectedLanguage) || '';
     const inputMaxWidth = getInputMaxWidth(props.component.style);
     const maxLengthValue = getStyleValueByKey(props.component.style, 'maxLength');
-    const rowsValue = getStyleValueByKey(props.component.style, 'rows');
-    const isMultiline = rowsValue && parseInt(rowsValue) != 1;
+    const isMultiline = props.component.role === 'multilineTextInput';
 
     return (
         <div className='space-y-4'
@@ -95,38 +94,25 @@ const TextInputContentConfig: React.FC<TextInputContentConfigProps> = (props) =>
                 />
             </div>
 
-            {props.allowMultipleLines && <div className='space-y-1.5'>
+            {props.allowMultipleLines &&
                 <Label
-                    htmlFor={props.component.key + 'rows'}
+                    className='flex gap-2 items-center'
                 >
-                    Text rows (visible lines)
+
+                    <Switch
+
+                        checked={isMultiline}
+                        onCheckedChange={(checked) => {
+                            const updatedComponent = { ...props.component };
+                            updatedComponent.role = checked ? 'multilineTextInput' : 'input';
+                            props.onChange(updatedComponent);
+                        }} />
+
+                    <span>
+                        Use multiline text input
+                    </span>
                 </Label>
-                <Input
-                    id={props.component.key + 'rows'}
-                    value={rowsValue || '1'}
-                    type='number'
-                    min={1}
-                    max={25}
-                    step={1}
-                    onChange={(e) => {
-                        const updatedComponent = { ...props.component };
-                        const updatedStyle = [...updatedComponent.style || []];
-                        const index = updatedStyle.findIndex(s => s.key === 'rows');
-                        if (index > -1) {
-                            updatedStyle[index] = { key: 'rows', value: e.target.value };
-                        } else {
-                            updatedStyle.push({ key: 'rows', value: e.target.value });
-                        }
-                        updatedComponent.style = updatedStyle;
-                        if (e.target.value == '1') {
-                            updatedComponent.role = 'input';
-                        } else {
-                            updatedComponent.role = 'multilineTextInput';
-                        }
-                        props.onChange(updatedComponent);
-                    }}
-                />
-            </div>}
+            }
 
             {!isMultiline && <div className='space-y-1.5'>
                 <Label

--- a/components/survey-renderer/SurveySingleItemView/ResponseComponent/InputTypes/MultilineTextInput.tsx
+++ b/components/survey-renderer/SurveySingleItemView/ResponseComponent/InputTypes/MultilineTextInput.tsx
@@ -51,7 +51,6 @@ const MultilineTextInput: React.FC<MultilineTextInputProps> = (props) => {
     };
 
     const maxLengthValue = getStyleValueByKey(props.compDef.style, 'maxLength');
-    const rows = parseInt(getStyleValueByKey(props.compDef.style, 'rows') ?? "3");
     const fullKey = [props.parentKey, props.compDef.key].join('.');
     return (
         <div
@@ -71,7 +70,8 @@ const MultilineTextInput: React.FC<MultilineTextInputProps> = (props) => {
                     placeholder={getLocaleStringTextByCode(props.compDef.description, props.languageCode)}
                     value={inputValue}
                     maxLength={maxLengthValue ? parseInt(maxLengthValue) : 4000}
-                    rows={rows}
+                    className='resize-none field-sizing-content'
+                    rows={5}
                     onChange={handleInputValueChange(props.compDef.key)}
                     disabled={props.compDef.disabled !== undefined}
                 />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -68,6 +68,10 @@
 }
 
 @layer utilities {
+    .field-sizing-content {
+        field-sizing: content;
+    }
+
     .fst-italic {
         @apply italic;
     }


### PR DESCRIPTION
Use field-sizing-content to auto-resize textarea on browsers supporting it and improving the handling of multiline text inputs and simplifying the configuration process.

Improvements to text input components:

* [`components/survey-editor/components/ItemEditor/editor/components/content-editor/response-editors/text-input-content-config.tsx`](diffhunk://#diff-37a58ebb25bdcae4a9d45eac2e05f18e6b4ccdbacc1a4b40f21d36c7f34fc61dL25-R25): Modified the logic to determine if an input is multiline based on the `role` property instead of the `rows` style value. Added a `Switch` component to toggle between single-line and multiline text inputs. [[1]](diffhunk://#diff-37a58ebb25bdcae4a9d45eac2e05f18e6b4ccdbacc1a4b40f21d36c7f34fc61dL25-R25) [[2]](diffhunk://#diff-37a58ebb25bdcae4a9d45eac2e05f18e6b4ccdbacc1a4b40f21d36c7f34fc61dL98-R115)

* [`components/survey-renderer/SurveySingleItemView/ResponseComponent/InputTypes/MultilineTextInput.tsx`](diffhunk://#diff-ae5e7a5bc08580169bb9239f39217c6c1636f2fd734b718e43b451427fd905ebL54): Removed the dependency on the `rows` style value and set a default row count for multiline text inputs. [[1]](diffhunk://#diff-ae5e7a5bc08580169bb9239f39217c6c1636f2fd734b718e43b451427fd905ebL54) [[2]](diffhunk://#diff-ae5e7a5bc08580169bb9239f39217c6c1636f2fd734b718e43b451427fd905ebL74-R74)

Styling updates:

* [`styles/globals.css`](diffhunk://#diff-4ee0e71a2145586038d583d58bcbd7aaa6b42318f417f5b62f2cbee48931861bR71-R74): Added a new utility class `.field-sizing-content` to handle the sizing of text input fields. (In tailwind v4 it's already included, so this can be removed when migrated)