### PR TITLE
Improve template creation

### DIFF
--- a/app/(default)/tools/messaging/email-templates/_components/EmailTemplateConfigurator.tsx
+++ b/app/(default)/tools/messaging/email-templates/_components/EmailTemplateConfigurator.tsx
@@ -21,6 +21,7 @@ interface EmailTemplateConfiguratorProps {
     messageType?: string;
     isSystemTemplate: boolean;
     isGlobalTemplate?: boolean;
+    availableStudyKeys?: string[];
 }
 
 const initialEmailTemplate: EmailTemplate = {
@@ -148,6 +149,7 @@ const EmailTemplateConfigurator: React.FC<EmailTemplateConfiguratorProps> = (pro
                                 isNewTemplate={!props.emailTemplateConfig}
                                 isSystemTemplate={props.isSystemTemplate}
                                 isGlobalTemplate={props.isGlobalTemplate}
+                                availableStudyKeys={props.availableStudyKeys}
                                 onChange={(newConfig) => {
                                     setIsDirty(true);
                                     setEmailTemplateConfig(newConfig)

--- a/app/(default)/tools/messaging/email-templates/_components/MessageConfig.tsx
+++ b/app/(default)/tools/messaging/email-templates/_components/MessageConfig.tsx
@@ -57,7 +57,9 @@ const MessageConfig: React.FC<MessageConfigProps> = (props) => {
                             placeholder='Enter the message type'
                             value={props.emailTemplateConfig.messageType ?? ''}
                             onChange={(event) => {
-                                const value = event.target.value;
+                                let value = event.target.value;
+                                value = value.trim().replaceAll(' ', '-').replaceAll('/', '-').replaceAll('?', '').replaceAll('&', '').replaceAll('"', '').replaceAll("'", '').replaceAll('(', '').replaceAll(')', '').replaceAll('[', '').replaceAll(']', '').replaceAll('{', '').replaceAll('}', '').replaceAll('<', '').replaceAll('>', '').replaceAll(':', '').replaceAll(';', '').replaceAll(',', '').replaceAll('\\', '');
+
                                 const newEmailTemplateConfig = { ...props.emailTemplateConfig };
                                 newEmailTemplateConfig.messageType = value;
                                 props.onChange(newEmailTemplateConfig);

--- a/app/(default)/tools/messaging/email-templates/_components/MessageConfig.tsx
+++ b/app/(default)/tools/messaging/email-templates/_components/MessageConfig.tsx
@@ -1,6 +1,7 @@
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Separator } from '@/components/ui/separator';
 import { Switch } from '@/components/ui/switch';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
@@ -14,10 +15,18 @@ interface MessageConfigProps {
     isNewTemplate: boolean;
     isSystemTemplate?: boolean;
     isGlobalTemplate?: boolean;
+    availableStudyKeys?: string[];
     onChange: (template: EmailTemplate) => void;
 }
 
 const MessageConfig: React.FC<MessageConfigProps> = (props) => {
+    const availableStudyKeys = props.availableStudyKeys ?? [];
+    if (props.emailTemplateConfig.studyKey && !availableStudyKeys.includes(props.emailTemplateConfig.studyKey)) {
+        availableStudyKeys.push(props.emailTemplateConfig.studyKey);
+    }
+
+    console.log(availableStudyKeys)
+
     return (
         <TooltipProvider>
             <div className='p-4 min-w-96 max-w-96 space-y-4'>
@@ -70,18 +79,28 @@ const MessageConfig: React.FC<MessageConfigProps> = (props) => {
                                 </TooltipContent>
                             </Tooltip>
                         </Label>
-                        <Input
-                            id='study-key'
-                            placeholder='Enter a study key'
-                            readOnly={!props.isNewTemplate}
+                        <Select
+                            //id='study-key'
+                            disabled={!props.isNewTemplate}
                             value={props.emailTemplateConfig.studyKey ?? ''}
-                            onChange={(event) => {
-                                const value = event.target.value;
+                            onValueChange={(value) => {
                                 const newEmailTemplateConfig = { ...props.emailTemplateConfig };
                                 newEmailTemplateConfig.studyKey = value;
                                 props.onChange(newEmailTemplateConfig);
                             }}
-                        />
+                        >
+                            <SelectTrigger>
+                                <SelectValue placeholder="Select a study key..." />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {availableStudyKeys?.map((studyKey) => {
+                                    return <SelectItem
+                                        key={studyKey}
+                                        value={studyKey}
+                                    >{studyKey}</SelectItem>
+                                })}
+                            </SelectContent>
+                        </Select>
                     </div>}
 
                     <Separator />

--- a/app/(default)/tools/messaging/email-templates/_components/MessageConfig.tsx
+++ b/app/(default)/tools/messaging/email-templates/_components/MessageConfig.tsx
@@ -25,8 +25,6 @@ const MessageConfig: React.FC<MessageConfigProps> = (props) => {
         availableStudyKeys.push(props.emailTemplateConfig.studyKey);
     }
 
-    console.log(availableStudyKeys)
-
     return (
         <TooltipProvider>
             <div className='p-4 min-w-96 max-w-96 space-y-4'>

--- a/app/(default)/tools/messaging/email-templates/study-templates/create-new-template/page.tsx
+++ b/app/(default)/tools/messaging/email-templates/study-templates/create-new-template/page.tsx
@@ -1,9 +1,14 @@
+import { getStudies } from "@/lib/data/studyAPI";
 import EmailTemplateConfigurator from "../../_components/EmailTemplateConfigurator";
 import SimpleBreadcrumbsPageLayout from "@/components/SimpleBreadcrumbsPageLayout";
 
 export const dynamic = 'force-dynamic';
 
-export default function Page() {
+export default async function Page() {
+
+    const studies = await getStudies();
+    const availableStudyKeys = studies.studies?.map(s => s.key);
+    console.log(availableStudyKeys)
 
     return (
         <SimpleBreadcrumbsPageLayout
@@ -31,6 +36,7 @@ export default function Page() {
                         messageType={`new-message-${(Math.random() * 100).toFixed(0)}`}
                         isSystemTemplate={false}
                         isGlobalTemplate={false}
+                        availableStudyKeys={availableStudyKeys}
                     />
                 </div>
             </div>


### PR DESCRIPTION
This pull request introduces a new feature to support selecting study keys in email template configuration and improves input sanitization for message types. The changes include adding support for dynamically fetching and displaying available study keys, replacing the study key input field with a dropdown, and sanitizing the message type input to prevent invalid characters.

### New feature: Study key selection
* Added a new `availableStudyKeys` property to the `EmailTemplateConfiguratorProps` and `MessageConfigProps` interfaces to pass available study keys for dropdown selection. (`app/(default)/tools/messaging/email-templates/_components/EmailTemplateConfigurator.tsx` - [[1]](diffhunk://#diff-3bcac382ee57442fd1288c115d2258422c10c797cf943019773f5744ddffd549R24) [[2]](diffhunk://#diff-3bcac382ee57442fd1288c115d2258422c10c797cf943019773f5744ddffd549R152); `app/(default)/tools/messaging/email-templates/_components/MessageConfig.tsx` - [[3]](diffhunk://#diff-3e62f60a2593994b0ba013905bff5cf339568fe3ca6d6ec7579c86461223ac9eR18-R29)
* Replaced the study key input field with a `Select` dropdown component in `MessageConfig`, allowing users to choose from the available study keys. (`app/(default)/tools/messaging/email-templates/_components/MessageConfig.tsx` - [app/(default)/tools/messaging/email-templates/_components/MessageConfig.tsxL73-R105](diffhunk://#diff-3e62f60a2593994b0ba013905bff5cf339568fe3ca6d6ec7579c86461223ac9eL73-R105))
* Dynamically fetched study keys using the `getStudies` API in the `create-new-template` page and passed them to the `EmailTemplateConfigurator`. (`app/(default)/tools/messaging/email-templates/study-templates/create-new-template/page.tsx` - [[1]](diffhunk://#diff-04d74b1ed604bdd1d5bfba5b15775482d50ca36c4af875d32eb69f34488fd574R1-R11) [[2]](diffhunk://#diff-04d74b1ed604bdd1d5bfba5b15775482d50ca36c4af875d32eb69f34488fd574R39)

### Input sanitization improvements
* Enhanced sanitization for the `messageType` input in `MessageConfig` to remove invalid characters such as special symbols and spaces, ensuring a clean and valid value. (`app/(default)/tools/messaging/email-templates/_components/MessageConfig.tsx` - [app/(default)/tools/messaging/email-templates/_components/MessageConfig.tsxL51-R62](diffhunk://#diff-3e62f60a2593994b0ba013905bff5cf339568fe3ca6d6ec7579c86461223ac9eL51-R62))