### PR TITLE
Messaging tool improvements

### DIFF
--- a/app/(default)/tools/messaging/schedules/_components/ScheduleCard.tsx
+++ b/app/(default)/tools/messaging/schedules/_components/ScheduleCard.tsx
@@ -1,9 +1,10 @@
 import { MessageSchedule } from '@/utils/server/types/messaging';
 import { formatDistanceStrict } from 'date-fns';
-import { dateFromTimestamp, formatTimestamp } from '../utils';
+import { dateFromTimestamp } from '../utils';
 import { Badge } from '@/components/ui/badge';
 import { CalendarClock, RefreshCw } from 'lucide-react';
 import { LinkMenuItem } from '@/components/LinkMenu';
+import ClientSideDateTimeDisplay from './client-side-datetime-display';
 
 
 const ScheduleCard: React.FC<{ schedule: MessageSchedule }> = ({ schedule }) => {
@@ -34,7 +35,7 @@ const ScheduleCard: React.FC<{ schedule: MessageSchedule }> = ({ schedule }) => 
                         <CalendarClock className="size-5" />
                     </span>
                     <span className="px-1">
-                        {formatTimestamp(schedule.nextTime)}
+                        <ClientSideDateTimeDisplay dateTime={dateFromTimestamp(schedule.nextTime)} />
                     </span>
                 </div>
 

--- a/app/(default)/tools/messaging/schedules/_components/client-side-datetime-display.tsx
+++ b/app/(default)/tools/messaging/schedules/_components/client-side-datetime-display.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { format } from "date-fns";
+import React from "react";
+
+interface ClientSideDateTimeDisplayProps {
+    dateTime: Date;
+}
+
+const ClientSideDateTimeDisplay: React.FC<ClientSideDateTimeDisplayProps> = (props) => {
+    const [renderedTime, setRenderedTime] = React.useState(format(props.dateTime, 'yyyy-MM-dd HH:mm'))
+
+    React.useEffect(() => {
+        setRenderedTime(format(props.dateTime, 'yyyy-MM-dd HH:mm'))
+    }, [props.dateTime]);
+
+    return (
+        <time dateTime={props.dateTime.toISOString()}>
+            {renderedTime}
+        </time>
+    )
+}
+
+export default ClientSideDateTimeDisplay;

--- a/app/(default)/tools/messaging/schedules/page.tsx
+++ b/app/(default)/tools/messaging/schedules/page.tsx
@@ -19,7 +19,7 @@ export default async function Page() {
                 ]
             }
         >
-            <div className="flex">
+            <div className="flex pb-12">
                 <Suspense fallback={<ScheduledEmailsSkeleton />}>
                     <ScheduledEmails />
                 </Suspense>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -65,7 +65,7 @@ export const SidebarItem: React.FC<SidebarItemProps> = (props) => {
                 <Button
                     type='button'
                     className={clsx(
-                        'w-12 h-12 text-2xl rounded-full hover:rounded-md transition-all duration-200',
+                        'w-12 h-12 text-2xl rounded-full hover:rounded-md transition-all duration-200 [&_svg]:size-5',
                         {
                             'rounded-md': props.isActive,
                         }

--- a/components/SimpleBreadcrumbsPageLayout.tsx
+++ b/components/SimpleBreadcrumbsPageLayout.tsx
@@ -11,13 +11,13 @@ interface SimpleBreadcrumbsPageLayoutProps {
 
 const SimpleBreadcrumbsPageLayout: React.FC<SimpleBreadcrumbsPageLayoutProps> = (props) => {
     return (
-        <div className="px-6 h-full">
-            <div className="pt-3 flex gap-8">
+        <div className="px-6 overflow-y-auto">
+            <div className="pt-3">
                 <Breadcrumbs
                     links={props.links}
                 />
             </div>
-            <main className="py-6 h-full">
+            <main className="py-6">
                 {props.children}
             </main>
         </div>


### PR DESCRIPTION
This pull request introduces a new `ClientSideDateTimeDisplay` component for rendering date-time values on the client side, replaces server-side date formatting in `ScheduleCard` with this new component, and includes several minor UI adjustments across the codebase. Below are the most significant changes:

### New Component for Client-Side Date-Time Rendering:
* Added a new `ClientSideDateTimeDisplay` component in `app/(default)/tools/messaging/schedules/_components/client-side-datetime-display.tsx`. This component formats and displays a `Date` object on the client side using `date-fns`. (`[app/(default)/tools/messaging/schedules/_components/client-side-datetime-display.tsxR1-R24](diffhunk://#diff-dd986eda29bdded5d66f7165db2d9b73a85eadd6b41067462e42bfec0ebbdb66R1-R24)`)

### Refactoring in `ScheduleCard`:
* Replaced the `formatTimestamp` function with the `ClientSideDateTimeDisplay` component for rendering the `nextTime` property in `ScheduleCard`. This ensures date-time values are formatted on the client side. (`[app/(default)/tools/messaging/schedules/_components/ScheduleCard.tsxL37-R38](diffhunk://#diff-f9493814eb34ea3a38f91da10f180156e24e58a112b709167c7d38981779d989L37-R38)`)
* Removed the unused `formatTimestamp` import from `ScheduleCard.tsx`. (`[app/(default)/tools/messaging/schedules/_components/ScheduleCard.tsxL3-R7](diffhunk://#diff-f9493814eb34ea3a38f91da10f180156e24e58a112b709167c7d38981779d989L3-R7)`)

### Minor UI Adjustments:
* Added padding (`pb-12`) to the container in `page.tsx` to improve layout spacing. (`[app/(default)/tools/messaging/schedules/page.tsxL22-R22](diffhunk://#diff-7ebbed4ccec28cfc22c1f56a278e6fe0809e6b93b92b72d74d7bddf807ebc86bL22-R22)`)
* Updated the `SidebarItem` button styles to include a size adjustment for nested SVG elements (`[&_svg]:size-5`). (`[components/Sidebar.tsxL68-R68](diffhunk://#diff-c167446e1835b2acfce0e9b5abda1a3ce59ca84f26cbb0ad20e75d2eceac076aL68-R68)`)
* Modified the layout in `SimpleBreadcrumbsPageLayout` to make the container scrollable (`overflow-y-auto`) and removed unnecessary height constraints. (`[components/SimpleBreadcrumbsPageLayout.tsxL14-R20](diffhunk://#diff-567df63e6f55988acbc59b2aa8d99453ab2205047728a8167110dd5bd1d62158L14-R20)`)