### PR TITLE
Fix available keys not updating

### DIFF
--- a/components/survey-editor/components/ItemEditor/editor/components/conditions-editor/conditions-editor.tsx
+++ b/components/survey-editor/components/ItemEditor/editor/components/conditions-editor/conditions-editor.tsx
@@ -108,7 +108,8 @@ export function extractSurveyKeys(surveyData?: Survey): {
 
     // Start processing from the survey definition
     if (surveyData.surveyDefinition && surveyData.surveyDefinition.items) {
-        surveyData.surveyDefinition.items.forEach(processSurveyItem);
+        processSurveyItem(surveyData.surveyDefinition)
+        // surveyData.surveyDefinition.items.forEach(processSurveyItem);
     }
 
     return {
@@ -126,9 +127,6 @@ const ConditionsEditor: React.FC<ConditionsEditorProps> = (props) => {
     const currentExpArgSlot = props.surveyItem.condition?.name;
 
     const { singleChoiceKeys, multipleChoiceKeys, allItemKeys } = extractSurveyKeys(survey);
-
-    console.log('currentCondition', currentCondition)
-
 
     return (
         <div className='p-4 space-y-4 pb-24' >

--- a/components/survey-renderer/SurveyView/SurveyView.tsx
+++ b/components/survey-renderer/SurveyView/SurveyView.tsx
@@ -73,6 +73,10 @@ const SurveyView: React.FC<SurveyViewProps> = (props) => {
     // console.log(surveyEngine.getSurveyEndItem());
 
     const renderCurrentPage = () => {
+        if (!surveyPages || surveyPages.length === 0) {
+            return <p className='text-center text-destructive'>Error during computing survey pages</p>
+        }
+
         if (currentPage < 0 || currentPage > surveyPages.length - 1) {
             setCurrentPage(0);
             return;

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
 		"rehype-slug": "^6.0.0",
 		"remark-gfm": "^4.0.0",
 		"sonner": "^1.7.2",
-		"survey-engine": "^1.3.1",
+		"survey-engine": "^1.3.2",
 		"swr": "^2.2.4",
 		"tailwind-merge": "^2.5.2",
 		"tailwindcss-animate": "^1.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6401,10 +6401,17 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-survey-engine@^1.2.0, survey-engine@^1.3.1:
+survey-engine@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/survey-engine/-/survey-engine-1.3.1.tgz#2c5a8e0b4f60c100f6aac2e3a050b6f70a188755"
   integrity sha512-q7i3xsAXSOT7ksqC4SooPnT586EhdrGqTcDJ+XNyZt9Zej6VtAPyiBJSpZdE85kJEQuvPW+0S0Y/mxjk1svdqA==
+  dependencies:
+    date-fns "^2.29.3"
+
+survey-engine@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/survey-engine/-/survey-engine-1.3.2.tgz#f21f726fa52c5109039ad13a980255bfbcdb255b"
+  integrity sha512-SVrNMkvvIaUan0kBl005Mzk5KJ4IbQkEB1TT1QZegFrEdFX57RhZsL0oWaU8rfViUfzSGH2pjuojRthsQzWRbw==
   dependencies:
     date-fns "^2.29.3"
 


### PR DESCRIPTION
This pull request includes changes to improve survey rendering error handling, streamline survey key extraction, and update a package dependency. Below is a summary of the most important changes:

### Improvements to error handling:

* [`components/survey-renderer/SurveyView/SurveyView.tsx`](diffhunk://#diff-589841c1093ff829192c38ff6d600c0b73fe94eafdc645e784ae24aab9370527R76-R79): Added a check to render an error message if `surveyPages` is undefined or empty during survey rendering.

### Code cleanup and optimization:

* [`components/survey-editor/components/ItemEditor/editor/components/conditions-editor/conditions-editor.tsx`](diffhunk://#diff-9200ddcf45b84708378f9e296d0ebfc1ba3f574cefd047520f9c7b4c0d033107L111-R112): Modified `extractSurveyKeys` to process the entire survey definition directly instead of iterating over individual items. Removed an unnecessary `console.log` statement in the `ConditionsEditor` component. [[1]](diffhunk://#diff-9200ddcf45b84708378f9e296d0ebfc1ba3f574cefd047520f9c7b4c0d033107L111-R112) [[2]](diffhunk://#diff-9200ddcf45b84708378f9e296d0ebfc1ba3f574cefd047520f9c7b4c0d033107L130-L132)

### Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L77-R77): Updated the `survey-engine` package from version `^1.3.1` to `^1.3.2`.