### PR TITLE
Improve nextTime and until Date Input Validation in Schedule Editor

### DIFF
--- a/app/(default)/tools/messaging/schedules/[scheduleId]/page.tsx
+++ b/app/(default)/tools/messaging/schedules/[scheduleId]/page.tsx
@@ -18,7 +18,7 @@ export default function Page(
                     href: '/tools/messaging',
                 },
                 {
-                    title: 'Schedules emails',
+                    title: 'Scheduled emails',
                     href: '/tools/messaging/schedules',
                 },
                 {

--- a/app/(default)/tools/messaging/schedules/_components/ScheduleEditor.tsx
+++ b/app/(default)/tools/messaging/schedules/_components/ScheduleEditor.tsx
@@ -60,6 +60,11 @@ const ScheduleEditor: React.FC<ScheduleEditorProps> = (props) => {
     const [nextTimeInput, setNextTimeInput] = useState(
         dateToInputStr(new Date((props.schedule ?? initialSchedule).nextTime * 1000))
     );
+    const [untilInput, setUntilInput] = useState(
+        (props.schedule?.until && Number.isFinite(props.schedule.until) && props.schedule.until > 0)
+            ? dateToInputStr(new Date(props.schedule.until * 1000))
+            : ''
+    );
 
 
     const [currentDateTime, setCurrentDateTime] = React.useState(new Date());
@@ -70,6 +75,14 @@ const ScheduleEditor: React.FC<ScheduleEditorProps> = (props) => {
     useEffect(() => {
         setNextTimeInput(dateToInputStr(new Date(schedule.nextTime * 1000)));
     }, [schedule.nextTime]);
+
+    useEffect(() => {
+        if (schedule.until && Number.isFinite(schedule.until) && schedule.until > 0) {
+            setUntilInput(dateToInputStr(new Date(schedule.until * 1000)));
+            return;
+        }
+        setUntilInput('');
+    }, [schedule.until]);
 
 
     const onSaveSchedule = () => {
@@ -384,8 +397,9 @@ const ScheduleEditor: React.FC<ScheduleEditorProps> = (props) => {
                                             <div className='shrink-0 flex items-center'>
                                                 <Switch
                                                     id='auto-delete'
-                                                    checked={schedule.until !== null && schedule.until !== undefined && schedule.until !== 0}
+                                                    checked={Boolean(schedule.until && Number.isFinite(schedule.until) && schedule.until > 0)}
                                                     onCheckedChange={(value) => {
+                                                        setIsDirty(true);
                                                         setSchedule((s) => {
                                                             const newSchedule = { ...s };
                                                             if (value) {
@@ -424,17 +438,39 @@ const ScheduleEditor: React.FC<ScheduleEditorProps> = (props) => {
                                                         id='schedule-until-time'
                                                         type='datetime-local'
                                                         placeholder='enter a time...'
-                                                        disabled={!schedule.until}
-                                                        value={dateToInputStr(new Date((schedule.until || 0) * 1000))}
+                                                        disabled={!(schedule.until && Number.isFinite(schedule.until) && schedule.until > 0)}
+                                                        value={untilInput}
                                                         min={dateToInputStr(currentDateTime)}
                                                         max={dateToInputStr(addMonths(currentDateTime, 24))}
                                                         onChange={(event) => {
-                                                            const value = event.target.value;
+                                                            setUntilInput(event.target.value);
+                                                        }}
+                                                        onBlur={() => {
+                                                            if (!(schedule.until && Number.isFinite(schedule.until) && schedule.until > 0)) {
+                                                                return;
+                                                            }
+
+                                                            const parsed = new Date(untilInput).getTime();
+                                                            if (Number.isNaN(parsed)) {
+                                                                toast.error('Please enter a valid date and time.');
+                                                                setUntilInput(dateToInputStr(new Date(schedule.until * 1000)));
+                                                                return;
+                                                            }
+
+                                                            const minAllowed = currentDateTime.getTime();
+                                                            const maxAllowed = addMonths(currentDateTime, 24).getTime();
+                                                            if (parsed < minAllowed || parsed > maxAllowed) {
+                                                                toast.error('Please select a date between now and two years from now.');
+                                                                setUntilInput(dateToInputStr(new Date(schedule.until * 1000)));
+                                                                return;
+                                                            }
+
+                                                            const until = Math.floor(parsed / 1000);
                                                             setIsDirty(true);
-                                                            setSchedule({
-                                                                ...schedule,
-                                                                until: Math.floor(new Date(value).getTime() / 1000)
-                                                            })
+                                                            setSchedule((s) => ({
+                                                                ...s,
+                                                                until,
+                                                            }));
                                                         }}
                                                     />
                                                 </div>

--- a/app/(default)/tools/messaging/schedules/_components/ScheduleEditor.tsx
+++ b/app/(default)/tools/messaging/schedules/_components/ScheduleEditor.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import React, { useEffect, useState } from 'react';
 import { deleteMessageSchedule, saveMessageSchedule } from '../../../../../../actions/messaging/schedules';
 import NotImplemented from '@/components/NotImplemented';
-import { addHours, addMonths, addWeeks, format } from 'date-fns';
+import { addHours, addMinutes, addMonths, addWeeks, format } from 'date-fns';
 import { toast } from 'sonner';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import BackButton from '@/components/BackButton';
@@ -331,7 +331,7 @@ const ScheduleEditor: React.FC<ScheduleEditorProps> = (props) => {
                                                 type='datetime-local'
                                                 placeholder='enter next time...'
                                                 value={nextTimeInput}
-                                                min={dateToInputStr(currentDateTime)}
+                                                min={dateToInputStr(addMinutes(currentDateTime, -30))}
                                                 max={dateToInputStr(addMonths(currentDateTime, 12))}
                                                 onChange={(event) => {
                                                     setNextTimeInput(event.target.value);
@@ -344,7 +344,7 @@ const ScheduleEditor: React.FC<ScheduleEditorProps> = (props) => {
                                                         return;
                                                     }
 
-                                                    const minAllowed = currentDateTime.getTime();
+                                                    const minAllowed = addMinutes(currentDateTime, -30).getTime();
                                                     const maxAllowed = addMonths(currentDateTime, 12).getTime();
                                                     if (parsed < minAllowed || parsed > maxAllowed) {
                                                         toast.error('Please select a date between now and one year from now.');

--- a/app/(default)/tools/messaging/schedules/_components/ScheduleEditor.tsx
+++ b/app/(default)/tools/messaging/schedules/_components/ScheduleEditor.tsx
@@ -57,12 +57,19 @@ const ScheduleEditor: React.FC<ScheduleEditorProps> = (props) => {
         ...initialSchedule
     });
     const [isDirty, setIsDirty] = useState(false);
+    const [nextTimeInput, setNextTimeInput] = useState(
+        dateToInputStr(new Date((props.schedule ?? initialSchedule).nextTime * 1000))
+    );
 
 
     const [currentDateTime, setCurrentDateTime] = React.useState(new Date());
     useEffect(() => {
         setCurrentDateTime(new Date());
     }, []);
+
+    useEffect(() => {
+        setNextTimeInput(dateToInputStr(new Date(schedule.nextTime * 1000)));
+    }, [schedule.nextTime]);
 
 
     const onSaveSchedule = () => {
@@ -310,16 +317,34 @@ const ScheduleEditor: React.FC<ScheduleEditorProps> = (props) => {
                                                 id='schedule-next-time'
                                                 type='datetime-local'
                                                 placeholder='enter next time...'
-                                                value={dateToInputStr(new Date(schedule.nextTime * 1000))}
+                                                value={nextTimeInput}
                                                 min={dateToInputStr(currentDateTime)}
                                                 max={dateToInputStr(addMonths(currentDateTime, 12))}
                                                 onChange={(event) => {
-                                                    const value = event.target.value;
+                                                    setNextTimeInput(event.target.value);
+                                                }}
+                                                onBlur={() => {
+                                                    const parsed = new Date(nextTimeInput).getTime();
+                                                    if (Number.isNaN(parsed)) {
+                                                        toast.error('Please enter a valid date and time.');
+                                                        setNextTimeInput(dateToInputStr(new Date(schedule.nextTime * 1000)));
+                                                        return;
+                                                    }
+
+                                                    const minAllowed = currentDateTime.getTime();
+                                                    const maxAllowed = addMonths(currentDateTime, 12).getTime();
+                                                    if (parsed < minAllowed || parsed > maxAllowed) {
+                                                        toast.error('Please select a date between now and one year from now.');
+                                                        setNextTimeInput(dateToInputStr(new Date(schedule.nextTime * 1000)));
+                                                        return;
+                                                    }
+
+                                                    const nextTime = Math.floor(parsed / 1000);
                                                     setIsDirty(true);
-                                                    setSchedule({
-                                                        ...schedule,
-                                                        nextTime: Math.floor(new Date(value).getTime() / 1000)
-                                                    })
+                                                    setSchedule((s) => ({
+                                                        ...s,
+                                                        nextTime,
+                                                    }));
                                                 }}
                                             />
                                         </div>


### PR DESCRIPTION
nextTime now uses a draft input and only updates schedule.nextTime on blur after validation, preventing invalid values while typing (allowed range: now to +12 months).
until was updated the same way, with stable auto-delete toggle behavior and blur-time validation (allowed range: now to +24 months).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected breadcrumb label in the Schedules section.

* **Improvements**
  * Enhanced datetime input handling and validation in the schedule editor with clear error messages and revert on invalid entries.
  * "Until" field is now conditionally enabled and better synchronized with form state.
  * Auto-delete toggle now reliably reflects the presence of an "until" date and marks changes for saving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->