### PR TITLE
Add toggle for tracking account ID

### DIFF
--- a/actions/study/updateStudyProps.tsx
+++ b/actions/study/updateStudyProps.tsx
@@ -117,3 +117,28 @@ export const updateStudyDisplayProps = async (studyKey: string,
     revalidatePath('/tools/study-configurator');
     return resp.body;
 }
+
+export const updateStudyTrackAccount = async (studyKey: string, trackAccount: boolean): Promise<{
+    error?: string,
+    message?: string
+}> => {
+    const session = await auth();
+    if (!session || !session.CASEaccessToken) {
+        return { error: 'Unauthorized' };
+    }
+    const url = `/v1/studies/${studyKey}/track-account`;
+    const resp = await fetchCASEManagementAPI(
+        url,
+        session.CASEaccessToken,
+        {
+            method: 'PUT',
+            body: JSON.stringify({ trackAccount }),
+            revalidate: 0,
+        }
+    );
+    if (resp.status !== 200) {
+        return { error: `Failed to update track account: ${resp.status} - ${resp.body.error}` };
+    }
+    revalidatePath('/tools/study-configurator');
+    return resp.body;
+}

--- a/app/(default)/tools/study-configurator/[studyKey]/settings/_components/AccountIdTrackingCard.tsx
+++ b/app/(default)/tools/study-configurator/[studyKey]/settings/_components/AccountIdTrackingCard.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import WrapperCard from './WrapperCard';
+import { getStudy } from '@/lib/data/studyAPI';
+import ErrorAlert from '@/components/ErrorAlert';
+import AccountIdTrackingToggle from './AccountIdTrackingToggle';
+import { Skeleton } from '@/components/ui/skeleton';
+
+interface AccountIdTrackingCardProps {
+    studyKey: string;
+}
+
+const Wrapper = (props: { children: React.ReactNode }) => {
+    return (
+        <WrapperCard
+            title={'Account ID Tracking'}
+            description={'If enabled, the account ID is tracked for new participants. Participants from the same account can be identified, but the profile cannot be traced back.'}
+        >
+            {props.children}
+        </WrapperCard>
+    )
+}
+
+const AccountIdTrackingCard: React.FC<AccountIdTrackingCardProps> = async (props) => {
+    const resp = await getStudy(props.studyKey);
+
+    const error = resp.error;
+    if (error) {
+        return <ErrorAlert
+            title="Error loading account ID tracking settings"
+            error={error}
+        />
+    }
+
+    const study = resp.study;
+
+    return (
+        <Wrapper>
+            <AccountIdTrackingToggle
+                studyKey={props.studyKey}
+                trackAccount={study?.configs.trackAccount ?? false}
+            />
+        </Wrapper>
+    );
+};
+
+export default AccountIdTrackingCard;
+
+export const AccountIdTrackingCardSkeleton: React.FC = () => {
+    return (
+        <Wrapper>
+            <Skeleton className='h-8 w-20' />
+        </Wrapper>
+    );
+}

--- a/app/(default)/tools/study-configurator/[studyKey]/settings/_components/AccountIdTrackingToggle.tsx
+++ b/app/(default)/tools/study-configurator/[studyKey]/settings/_components/AccountIdTrackingToggle.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { updateStudyTrackAccount } from '@/actions/study/updateStudyProps';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import React from 'react';
+import { toast } from 'sonner';
+import getErrorMessage from '@/utils/getErrorMessage';
+
+interface AccountIdTrackingToggleProps {
+    studyKey: string;
+    trackAccount: boolean;
+}
+
+const AccountIdTrackingToggle: React.FC<AccountIdTrackingToggleProps> = (props) => {
+    const [isPending, startTransition] = React.useTransition();
+
+    return (
+        <div className='flex items-center'>
+            <Switch
+                id='accountIdTrackingToggle'
+                name='accountIdTrackingToggle'
+                checked={props.trackAccount}
+                onCheckedChange={(checked) => {
+                    startTransition(async () => {
+                        try {
+                            const resp = await updateStudyTrackAccount(props.studyKey, checked);
+                            if (resp.error) {
+                                toast.error(resp.error);
+                                return;
+                            }
+                            toast.success('Account ID tracking updated');
+                        } catch (error: unknown) {
+                            toast.error('An error occurred', { description: getErrorMessage(error) });
+                        }
+                    });
+                }}
+                disabled={isPending}
+            />
+            <Label
+                htmlFor='accountIdTrackingToggle'
+                className='ml-2'
+            >
+                Track account ID for new participants ({props.trackAccount ? 'Yes' : 'No'})
+            </Label>
+        </div>
+    );
+};
+
+export default AccountIdTrackingToggle;

--- a/app/(default)/tools/study-configurator/[studyKey]/settings/page.tsx
+++ b/app/(default)/tools/study-configurator/[studyKey]/settings/page.tsx
@@ -4,6 +4,7 @@ import { StudyKeyPageParams } from "../page";
 import IsDefaultStudyCard, { IsDefaultStudyCardSkeleton } from "./_components/IsDefaultStudyCard";
 import FileUploadCard, { FileUploadCardSkeleton } from "./_components/FileUploadCard";
 import DisplayTextsCard, { DisplayTextsCardSkeleton } from "./_components/DisplayTextsCard";
+import AccountIdTrackingCard, { AccountIdTrackingCardSkeleton } from "./_components/AccountIdTrackingCard";
 
 
 export const dynamic = 'force-dynamic';
@@ -30,6 +31,10 @@ export default function Page(props: StudyKeyPageParams) {
 
             <Suspense fallback={<FileUploadCardSkeleton />}>
                 <FileUploadCard studyKey={studyKey} />
+            </Suspense>
+
+            <Suspense fallback={<AccountIdTrackingCardSkeleton />}>
+                <AccountIdTrackingCard studyKey={studyKey} />
             </Suspense>
         </div>
     );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2017",
     "lib": [
       "dom",
       "dom.iterable",
@@ -13,12 +13,11 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": [
         "./*"

--- a/utils/server/types/studyInfos.ts
+++ b/utils/server/types/studyInfos.ts
@@ -25,6 +25,7 @@ export interface Study {
     configs: {
         idMappingMethod: string;
         participantFileUploadRule: Expression;
+        trackAccount: boolean;
     }
     stats: {
         participantCount: number;


### PR DESCRIPTION
This PR introduces a new feature that allows enabling or disabling account ID tracking for new study participants in the study configurator UI. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account ID tracking toggle to the study settings page, allowing users to enable or disable tracking of account IDs for new study participants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/case-framework/case-admin/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->